### PR TITLE
Implement due time with toggle status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Flask-ToDo-List
 
-A minimal Flask to-do application using SQLite.
+A minimal Flask to-do application using SQLite. Each task can have a due time and
+the interface allows toggling completion shortly before it is due.
 
 ## Requirements
 - Python 3.11
@@ -16,3 +17,6 @@ A minimal Flask to-do application using SQLite.
    python app.py
    ```
 3. Open your browser at <http://localhost:5000>.
+
+When adding a task you must also provide a due date and time. Tasks can be
+toggled complete only within the hour before they are due.

--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from flask import Flask, render_template, request, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
 
@@ -10,6 +12,7 @@ db = SQLAlchemy(app)
 class Task(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(200), nullable=False)
+    due_time = db.Column(db.DateTime, nullable=False)
     completed = db.Column(db.Boolean, default=False)
 
 with app.app_context():
@@ -17,13 +20,19 @@ with app.app_context():
 
 @app.route('/')
 def index():
-    tasks = Task.query.all()
+    tasks = Task.query.order_by(Task.due_time).all()
+    now = datetime.now()
+    for task in tasks:
+        diff = task.due_time - now
+        task.allow_toggle = 0 <= diff.total_seconds() <= 3600
     return render_template('index.html', tasks=tasks)
 
 @app.route('/add', methods=['POST'])
 def add():
     title = request.form['title']
-    task = Task(title=title)
+    due_time_str = request.form['due_time']
+    due_time = datetime.strptime(due_time_str, '%Y-%m-%dT%H:%M')
+    task = Task(title=title, due_time=due_time)
     db.session.add(task)
     db.session.commit()
     return redirect(url_for('index'))
@@ -34,6 +43,16 @@ def update(task_id):
     task.title = request.form.get('title', task.title)
     task.completed = 'completed' in request.form
     db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/toggle/<int:task_id>', methods=['POST'])
+def toggle(task_id):
+    task = Task.query.get_or_404(task_id)
+    now = datetime.now()
+    diff = task.due_time - now
+    if 0 <= diff.total_seconds() <= 3600:
+        task.completed = not task.completed
+        db.session.commit()
     return redirect(url_for('index'))
 
 @app.route('/delete/<int:task_id>', methods=['POST'])

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,27 +1,29 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>To-Do List</h1>
-<form action="{{ url_for('add') }}" method="post" class="mb-3">
-  <div class="input-group">
-    <input type="text" name="title" class="form-control" placeholder="New task" required>
-    <button class="btn btn-primary" type="submit">Add</button>
+<h1 class="mb-4 text-center">My Tasks</h1>
+<form action="{{ url_for('add') }}" method="post" class="row g-2 mb-4">
+  <div class="col-md-7">
+    <input type="text" name="title" class="form-control" placeholder="Task title" required>
+  </div>
+  <div class="col-md-3">
+    <input type="datetime-local" name="due_time" class="form-control" required>
+  </div>
+  <div class="col-md-2 d-grid">
+    <button class="btn btn-primary" type="submit">Add Task</button>
   </div>
 </form>
 <ul class="list-group">
   {% for task in tasks %}
-  <li class="list-group-item">
-    <div class="d-flex align-items-center">
-      <form action="{{ url_for('update', task_id=task.id) }}" method="post" class="d-flex flex-grow-1 me-2">
-        <div class="form-check me-2">
-          <input class="form-check-input" type="checkbox" name="completed" {% if task.completed %}checked{% endif %}>
-        </div>
-        <input type="text" name="title" value="{{ task.title }}" class="form-control me-2">
-        <button class="btn btn-success btn-sm">Save</button>
-      </form>
-      <form action="{{ url_for('delete', task_id=task.id) }}" method="post">
-        <button class="btn btn-danger btn-sm">Delete</button>
-      </form>
-    </div>
+  <li class="list-group-item d-flex align-items-center">
+    <span class="me-2">{{ '✅' if task.completed else '❎' }}</span>
+    <span class="me-2">{{ loop.index }}.</span>
+    <span class="flex-grow-1">{{ task.title }} - {{ task.due_time.strftime('%Y-%m-%d %H:%M') }}</span>
+    <form action="{{ url_for('toggle', task_id=task.id) }}" method="post" class="me-2">
+      <button class="btn btn-sm btn-outline-success" type="submit" {% if not task.allow_toggle %}disabled{% endif %}>Toggle</button>
+    </form>
+    <form action="{{ url_for('delete', task_id=task.id) }}" method="post">
+      <button class="btn btn-sm btn-outline-danger">Delete</button>
+    </form>
   </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- redesign index page with a cleaner layout
- store due time for tasks
- allow tasks to be toggled within 1 hour of due time
- order tasks by due time on the homepage
- document new due-time feature in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684d804d4e98832cb0fb69176b365049